### PR TITLE
Ajusta cor de fundo quando a lista de filmes ocupa apenas uma linha

### DIFF
--- a/src/components/Filmes/Filmes.css
+++ b/src/components/Filmes/Filmes.css
@@ -13,7 +13,7 @@ ul {
     text-align: center;
     padding: 5rem 0;
     background-color: var(--cor-de-fundo);
-    height: 100%;
+    min-height: 100vh;
 }
 
 .filmes img {


### PR DESCRIPTION
Esta PR corrige o comportamento visual da página de filmes, onde o fundo permanecia branco quando a lista de filmes ocupava apenas uma linha.
O ajuste garante que o fundo mantenha a cor esperada independentemente da quantidade de conteúdo renderizado, melhorando a consistência visual da interface em diferentes resoluções e tamanhos de tela.