### PR TITLE
Cria rodape com nome e ano de criação

### DIFF
--- a/src/components/Footer/Rodape.css
+++ b/src/components/Footer/Rodape.css
@@ -1,0 +1,8 @@
+.rodape {
+    position: relative;
+    background-color: var(--cor-de-fundo);
+    text-align: center;
+    color: white;
+    border-top: 1px solid var(--cor-detalhes);
+    padding: .5rem;
+}

--- a/src/components/Footer/Rodape.jsx
+++ b/src/components/Footer/Rodape.jsx
@@ -1,0 +1,11 @@
+import './Rodape.css'
+
+function Rodape() {
+  return (
+    <>
+    <p className="rodape">Marcos Nogueira | 2025</p>
+    </>
+  )
+}
+
+export default Rodape

--- a/src/pages/Filmes/Filmes.jsx
+++ b/src/pages/Filmes/Filmes.jsx
@@ -4,6 +4,7 @@ import './Filmes.css'
 import Carregando from '../../components/Carregando/Carregando'
 import Modal from '../../components/Modal/Modal'
 import Movies from '../../components/Movies/Movies'
+import Rodape from '../../components/Footer/Rodape'
 
 function Filmes() {
 
@@ -70,6 +71,8 @@ useEffect(() => {
       <Movies handleColor={handleColor} searchMovies={searchMovies} currentMovies={currentMovies} openModal={openModal}/>
 
       {modal && < Modal closeModal={closeModal} selectedMovie={selectedMovie}/>}
+
+      <Rodape />
     </>
   )
 }


### PR DESCRIPTION
Descrição:

Esta PR adiciona uma nova feature de rodapé (footer) que exibe o nome do criador e o ano de criação do site.
O objetivo é fornecer uma identidade visual mais completa e consistente em todas as páginas.

Alterações realizadas:

Criação do componente Footer

Inclusão do nome do criador e do ano de criação no layout

Aplicação de estilo responsivo para se adaptar a diferentes tamanhos de tela

Importação e renderização do Footer na estrutura principal da aplicação